### PR TITLE
feat: Added new function to call `status-go` `GetPasswordStrength` function

### DIFF
--- a/status_go.nim
+++ b/status_go.nim
@@ -294,3 +294,8 @@ proc imageServerTLSCert*(): string =
   var funcOut = go_shim.imageServerTLSCert()
   defer: go_shim.free(funcOut)
   return $funcOut
+
+proc getPasswordStrength*(paramsJSON: string): string =
+  var funcOut = go_shim.getPasswordStrength(paramsJSON.cstring)
+  defer: go_shim.free(funcOut)
+  return $funcOut

--- a/status_go/impl.nim
+++ b/status_go/impl.nim
@@ -120,3 +120,5 @@ proc getNodeConfig*(): cstring {.importc: "GetNodeConfig".}
 proc free*(param: pointer) {.importc: "Free".}
 
 proc imageServerTLSCert*(): cstring {.importc: "ImageServerTLSCert".}
+
+proc getPasswordStrength*(paramsJSON: cstring): cstring {.importc: "GetPasswordStrength".}


### PR DESCRIPTION
Here my first contribution to `nim-status-go`!

### What does the PR do
It has been added a new function that allows to get password strength quality information like Entropy, CrackTime, CrackTimeDisplay, Score, MatchSequence and CalcTime.

Together with [PR #5044](https://github.com/status-im/status-desktop/pull/5044) and [PR #2589](https://github.com/status-im/status-go/pull/2589) it closes [#4980](https://github.com/status-im/status-desktop/issues/4980)
