### PR TITLE
feat: Added new function to call to new status-go `GetPasswordStrengthScore` function

### DIFF
--- a/status_go.nim
+++ b/status_go.nim
@@ -309,3 +309,8 @@ proc getPasswordStrength*(paramsJSON: string): string =
   var funcOut = go_shim.getPasswordStrength(paramsJSON.cstring)
   defer: go_shim.free(funcOut)
   return $funcOut
+
+proc getPasswordStrengthScore*(paramsJSON: string): string =
+  var funcOut = go_shim.getPasswordStrengthScore(paramsJSON.cstring)
+  defer: go_shim.free(funcOut)
+  return $funcOut

--- a/status_go/impl.nim
+++ b/status_go/impl.nim
@@ -126,3 +126,5 @@ proc free*(param: pointer) {.importc: "Free".}
 proc imageServerTLSCert*(): cstring {.importc: "ImageServerTLSCert".}
 
 proc getPasswordStrength*(paramsJSON: cstring): cstring {.importc: "GetPasswordStrength".}
+
+proc getPasswordStrengthScore*(paramsJSON: cstring): cstring {.importc: "GetPasswordStrengthScore".}


### PR DESCRIPTION
### What does the PR do
It has been added a new function that allows to get password strength score information.

Closes [#5096](https://github.com/status-im/status-desktop/issues/5096) together with related `status-go` and `desktop` PRs.

**NOTE:** Added specific get score method althought there is already PasswordStrength one, that provides the same but extended information, due to an issue parsing JSON response in the NIM site since the `zxcvbn` returns big int crack time numbers when the password lenght is big and nim json cannot parse the response correctly. See the following [post](https://github.com/nim-lang/Nim/issues/15413).