### PR TITLE
Fix exception specifiers

### DIFF
--- a/status_go/impl.nim
+++ b/status_go/impl.nim
@@ -1,3 +1,6 @@
+# go functions do not raise nim exceptions and do not interact with the Nim gc
+{.push raises: [], gcsafe.}
+
 type SignalCallback* = proc(signal: cstring): void {.cdecl.}
 
 # All procs start with lowercase because the compiler will also need to import


### PR DESCRIPTION
Per
https://status-im.github.io/nim-style-guide/interop.c.html#functions-and-types, imported functions must be annotated with exception information.

If this is not done, Nim assumes the worst case that the function potentially could raise an exception which breaks compile-time exception safety analysis.